### PR TITLE
Update S3 support to AWS SDK v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
     # Must run after 'tests' job above
     needs: tests
     runs-on: ubuntu-latest
+    # Do not run on forks since it will fail without the token
+    if: github.repository == 'dspace/dspace'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -744,6 +744,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.38.12</version>
+        </dependency>
+
         <!-- TODO: This may need to be replaced with the "orcid-model" artifact once this ticket is resolved:
              https://github.com/ORCID/orcid-model/issues/50 -->
         <!-- Maintained at https://github.com/DSpace/orcid-model -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -649,7 +649,7 @@
             <version>1.1.1</version>
         </dependency>
 
-        <!-- guava is needed by OAuth, Guice, Mockserver, ORCID, s3mock, Solr, JClouds -->
+        <!-- guava is needed by OAuth, Guice, Mockserver, ORCID, Solr, JClouds -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -732,9 +732,16 @@
 
         <!-- S3 -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.785</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.32.31</version>
+            <exclusions>
+                <!-- Also included by SolrJ -->
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- TODO: This may need to be replaced with the "orcid-model" artifact once this ticket is resolved:
@@ -846,22 +853,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
-            <groupId>io.findify</groupId>
-            <artifactId>s3mock_2.13</artifactId>
-            <version>0.2.6</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.amazonawsl</groupId>
-                    <artifactId>aws-java-sdk-s3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.amazonaws</groupId>
-                    <artifactId>aws-java-sdk-s3</artifactId>
-                </exclusion>
-            </exclusions>
+          <groupId>com.adobe.testing</groupId>
+          <artifactId>s3mock-testcontainers</artifactId>
+          <version>4.8.0</version>
+          <scope>test</scope>
         </dependency>
 
         <!-- JClouds Assetstorage Support -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -736,11 +736,14 @@
             <artifactId>s3</artifactId>
             <version>2.32.31</version>
             <exclusions>
-                <!-- Also included by SolrJ -->
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
+              <exclusion>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>netty-nio-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>apache-client</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -150,8 +150,7 @@ public class S3BitStoreService extends BaseBitStoreService {
                 crtBuilder.maxConcurrency(maxConcurrency);
             }
 
-            return crtBuilder.targetThroughputInGbps(targetThroughput).minimumPartSizeInBytes(minPartSize)
-                     .credentialsProvider(credentialsProvider).build();
+            return crtBuilder.targetThroughputInGbps(targetThroughput).minimumPartSizeInBytes(minPartSize).build();
         };
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -126,11 +126,14 @@ public class S3BitStoreService extends BaseBitStoreService {
      *
      * @param regions wanted regions in client
      * @param awsCredentials credentials of the client
+     * @param targetThroughput target throughput in Gbps
+     * @param minPartSize minimum part size in bytes
+     * @param maxConcurrency maximum number of concurrent requests
      * @return builder with the specified parameters
      */
     protected static Supplier<S3AsyncClient> amazonClientBuilderBy(
-            @NotNull Region region,
-            @NotNull AwsCredentialsProvider credentialsProvider,
+            Region region,
+            AwsCredentialsProvider credentialsProvider,
             double targetThroughput,
             long minPartSize,
             Integer maxConcurrency

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -146,10 +146,6 @@ public class S3BitStoreService extends BaseBitStoreService {
                 crtBuilder.region(region);
             }
 
-            if (credentialsProvider != null) {
-                crtBuilder.credentialsProvider(credentialsProvider);
-            }
-
             if (maxConcurrency != null) {
                 crtBuilder.maxConcurrency(maxConcurrency);
             }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
 
-import jakarta.validation.constraints.NotNull;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -343,7 +343,7 @@ public class S3BitStoreService extends BaseBitStoreService {
             HeadObjectResponse response = s3Client.headObject(r -> r.bucket(bucketName).key(k));
 
             putValueIfExistsKey(attrs, metadata, "size_bytes", response.contentLength());
-            putValueIfExistsKey(attrs, metadata, "modified", valueOf(response.lastModified()));
+            putValueIfExistsKey(attrs, metadata, "modified", valueOf(response.lastModified().toEpochMilli()));
             putValueIfExistsKey(attrs, metadata, "checksum_algorithm", CSA);
 
             if (attrs.contains("checksum")) {

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -85,7 +85,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     public static void setupS3() {
         s3Mock.start();
 
-        s3AsyncClient = S3AsyncClient.builder()
+        s3AsyncClient = S3AsyncClient.crtBuilder()
                 .endpointOverride(URI.create("http://127.0.0.1:" + s3Mock.getHttpServerPort()))
                 .credentialsProvider(AnonymousCredentialsProvider.create())
                 .region(Region.US_EAST_1)

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -7,13 +7,12 @@
  */
 package org.dspace.storage.bitstore;
 
-import static com.amazonaws.regions.Regions.DEFAULT_REGION;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.dspace.storage.bitstore.S3BitStoreService.CSA;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -26,22 +25,15 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import io.findify.s3mock.S3Mock;
-import org.apache.commons.io.FileUtils;
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
@@ -59,47 +51,61 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-
-
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ObjectAttributes;
 
 /**
  * @author Luca Giamminonni (luca.giamminonni at 4science.com)
  */
 public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
+    private static  S3MockContainer s3Mock = new S3MockContainer("4.8.0");
+
+    private static S3Client s3Client;
 
     private static final String DEFAULT_BUCKET_NAME = "dspace-asset-localhost";
 
     private S3BitStoreService s3BitStoreService;
 
-    private AmazonS3 amazonS3Client;
-
-    private S3Mock s3Mock;
-
     private Collection collection;
-
-    private File s3Directory;
 
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
+    @BeforeClass
+    public static void setupS3() {
+        s3Mock.start();
+
+        s3Client = S3Client.builder()
+                .endpointOverride(URI.create("http://127.0.0.1:" + s3Mock.getHttpServerPort()))
+                .credentialsProvider(AnonymousCredentialsProvider.create())
+                .region(Region.US_EAST_1)
+                .build();
+    }
+
+    @AfterClass
+    public static void cleanupS3() {
+        s3Mock.close();
+        s3Client.close();
+    }
 
     @Before
     public void setup() throws Exception {
-
         configurationService.setProperty("assetstore.s3.enabled", "true");
-        s3Directory = new File(System.getProperty("java.io.tmpdir"), "s3");
 
-        s3Mock = S3Mock.create(8001, s3Directory.getAbsolutePath());
-        s3Mock.start();
-
-        amazonS3Client = createAmazonS3Client();
-
-        s3BitStoreService = new S3BitStoreService(amazonS3Client);
+        s3BitStoreService = new S3BitStoreService(s3Client);
         s3BitStoreService.setEnabled(BooleanUtils.toBoolean(
                 configurationService.getProperty("assetstore.s3.enabled")));
         s3BitStoreService.setBufferSize(22);
+
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -111,23 +117,17 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         context.restoreAuthSystemState();
     }
 
-    @After
-    public void cleanUp() throws IOException {
-        FileUtils.deleteDirectory(s3Directory);
-        s3Mock.shutdown();
-    }
-
     @Test
     public void testBitstreamPutAndGetWithAlreadyPresentBucket() throws IOException {
 
         String bucketName = "testbucket";
 
-        amazonS3Client.createBucket(bucketName);
+        s3Client.createBucket(r -> r.bucket(bucketName));
 
         s3BitStoreService.setBucketName(bucketName);
         s3BitStoreService.init();
 
-        assertThat(amazonS3Client.listBuckets(), contains(bucketNamed(bucketName)));
+        assertThat(s3Client.listBuckets().buckets(), hasItem(bucketNamed(bucketName)));
 
         context.turnOffAuthorisationSystem();
         String content                = "Test bitstream content";
@@ -149,7 +149,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
     private void checkGetPut(String bucketName, String content, Bitstream bitstream) throws IOException {
         s3BitStoreService.put(bitstream, toInputStream(content));
-        String expectedChecksum = Utils.toHex(generateChecksum(content));
+        String expectedChecksum = Utils.toHex(generateChecksum("MD5", content));
 
         assertThat(bitstream.getSizeBytes(), is((long) content.length()));
         assertThat(bitstream.getChecksum(), is(expectedChecksum));
@@ -159,18 +159,22 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         assertThat(IOUtils.toString(inputStream, UTF_8), is(content));
 
         String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
-        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(bucketName, key);
-        assertThat(objectMetadata.getContentMD5(), is(expectedChecksum));
+
+        GetObjectAttributesResponse response = s3Client.getObjectAttributes(r -> r.bucket(bucketName).key(key)
+                .objectAttributes(ObjectAttributes.CHECKSUM));
+
+        expectedChecksum = Base64.getEncoder().encodeToString(generateChecksum("SHA-256", content));
+        assertThat(response.checksum().checksumSHA256(), is(expectedChecksum));
     }
 
     @Test
-    public void testBitstreamPutAndGetWithoutSpecifingBucket() throws IOException {
+    public void testBitstreamPutAndGetWithoutSpecifyingBucket() throws IOException {
 
         s3BitStoreService.init();
 
         assertThat(s3BitStoreService.getBucketName(), is(DEFAULT_BUCKET_NAME));
 
-        assertThat(amazonS3Client.listBuckets(), contains(bucketNamed(DEFAULT_BUCKET_NAME)));
+        assertThat(s3Client.listBuckets().buckets(), hasItem(bucketNamed(DEFAULT_BUCKET_NAME)));
 
         context.turnOffAuthorisationSystem();
         String content = "Test bitstream content";
@@ -179,7 +183,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
         s3BitStoreService.put(bitstream, toInputStream(content));
 
-        String expectedChecksum = Utils.toHex(generateChecksum(content));
+        String expectedChecksum = Utils.toHex(generateChecksum("MD5", content));
 
         assertThat(bitstream.getSizeBytes(), is((long) content.length()));
         assertThat(bitstream.getChecksum(), is(expectedChecksum));
@@ -189,9 +193,11 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         assertThat(IOUtils.toString(inputStream, UTF_8), is(content));
 
         String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
-        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(DEFAULT_BUCKET_NAME, key);
-        assertThat(objectMetadata.getContentMD5(), is(expectedChecksum));
+        GetObjectAttributesResponse response = s3Client.getObjectAttributes(r -> r.bucket(DEFAULT_BUCKET_NAME).key(key)
+                .objectAttributes(ObjectAttributes.CHECKSUM));
 
+        expectedChecksum = Base64.getEncoder().encodeToString(generateChecksum("SHA-256", content));
+        assertThat(response.checksum().checksumSHA256(), is(expectedChecksum));
     }
 
     @Test
@@ -213,9 +219,9 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
         assertThat(key, startsWith("test/DSpace7/"));
 
-        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(DEFAULT_BUCKET_NAME, key);
-        assertThat(objectMetadata, notNullValue());
-
+        HeadObjectResponse response = s3Client.headObject(r ->
+            r.bucket(DEFAULT_BUCKET_NAME).key(key));
+        assertThat(response, notNullValue());
     }
 
     @Test
@@ -235,8 +241,8 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         s3BitStoreService.remove(bitstream);
 
         IOException exception = assertThrows(IOException.class, () -> s3BitStoreService.get(bitstream));
-        assertThat(exception.getCause(), instanceOf(AmazonS3Exception.class));
-        assertThat(((AmazonS3Exception) exception.getCause()).getStatusCode(), is(404));
+        assertThat(exception.getCause(), instanceOf(AwsServiceException.class));
+        assertThat(((AwsServiceException) exception.getCause()).statusCode(), is(404));
 
     }
 
@@ -264,7 +270,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         assertThat(about, hasEntry(is("modified"), notNullValue()));
         assertThat(about.size(), is(2));
 
-        String expectedChecksum = Utils.toHex(generateChecksum(content));
+        String expectedChecksum = Utils.toHex(generateChecksum("MD5", content));
 
         about = s3BitStoreService.about(bitstream, List.of("size_bytes", "modified", "checksum"));
         assertThat(about, hasEntry("size_bytes", 22L));
@@ -409,28 +415,21 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     public void testDoNotInitializeConfigured() throws Exception {
         String assetstores3enabledOldValue = configurationService.getProperty("assetstore.s3.enabled");
         configurationService.setProperty("assetstore.s3.enabled", "false");
-        s3BitStoreService = new S3BitStoreService(amazonS3Client);
+        s3BitStoreService = new S3BitStoreService(s3Client);
         s3BitStoreService.init();
         assertFalse(s3BitStoreService.isInitialized());
         assertFalse(s3BitStoreService.isEnabled());
         configurationService.setProperty("assetstore.s3.enabled", assetstores3enabledOldValue);
     }
 
-    private byte[] generateChecksum(String content) {
+    private byte[] generateChecksum(String algorithm, String content) {
         try {
-            MessageDigest m = MessageDigest.getInstance("MD5");
+            MessageDigest m = MessageDigest.getInstance(algorithm);
             m.update(content.getBytes());
             return m.digest();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private AmazonS3 createAmazonS3Client() {
-        return AmazonS3ClientBuilder.standard()
-            .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
-            .withEndpointConfiguration(new EndpointConfiguration("http://127.0.0.1:8001", DEFAULT_REGION.getName()))
-            .build();
     }
 
     private Item createItem() {
@@ -450,7 +449,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     }
 
     private Matcher<? super Bucket> bucketNamed(String name) {
-        return LambdaMatcher.matches(bucket -> bucket.getName().equals(name));
+        return LambdaMatcher.matches(bucket -> bucket.name().equals(name));
     }
 
     private InputStream toInputStream(String content) {

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -481,6 +481,13 @@
         </dependency>
 
         <!-- DSpace dependencies -->
+
+        <!-- Moved here from optional modules list to ensure that iiif-apis mime.types resource is first in classpath -->
+        <dependency>
+            <groupId>org.dspace</groupId>
+            <artifactId>dspace-iiif</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
@@ -500,10 +507,6 @@
 
         <!-- DSpace modules to deploy (these modules are all optional, but add features/endpoints to webapp) -->
         <!-- You may choose to comment out any of these modules if you do not want/need its features -->
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-iiif</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-oai</artifactId>

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -56,6 +56,20 @@ assetstore.s3.awsSecretKey =
 # then this setting is ignored and the default AWS region will be used.
 assetstore.s3.awsRegionName =
 
+# The target throughput for transfer requests in Gbps. Higher value means more connections will be established with S3.
+assetstore.s3.targetThroughputGbps = 10.0
+
+# Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer to be split
+# into a larger number of smaller parts.
+assetstore.s3.minPartSizeBytes = 8388608
+
+# Specifies the maximum number of S3 connections that should be established during a transfer.
+# If not provided, it will be based on targetThroughputGbps
+assetstore.s3.maxConcurrency = 
+
+# The algorithm the S3 client will use to create a checksum when doing putObject.
+assetstore.s3.s3ChecksumAlgorithm = CRC32
+
 
 ### JCloudSettings
 # Configuration for JCloudstore, see config/spring/api/bitstore.xml for more options

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -35,6 +35,22 @@
         <!-- Subfolder to organize assets within the bucket, in case this bucket is shared  -->
         <!-- Optional, default is root level of bucket -->
         <property name="subfolder" value="${assetstore.s3.subfolder}"/>
+
+        <!-- The target throughput for transfer requests in Gbps. Higher value means more connections will be established with S3.  -->
+        <property name="targetThroughputGbps" value="${assetstore.s3.targetThroughputGbps}"/>
+
+        <!-- Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer
+             to be split into a larger number of smaller parts.
+        -->
+        <property name="minPartSizeBytes" value="${assetstore.s3.minPartSizeBytes}"/>
+
+        <!-- Specifies the maximum number of S3 connections that should be established during a transfer.
+             If not provided, it will be based on targetThroughputGbps
+        -->
+        <property name="maxConcurrency" value="${assetstore.s3.maxConcurrency}"/>
+
+        <!-- The algorithm the S3 client will use to create a checksum when doing putObject. -->        
+        <property name="s3ChecksumAlgorithm" value="${assetstore.s3.s3ChecksumAlgorithm}"/>        
     </bean>
 
     <!-- 


### PR DESCRIPTION
Update to AWS SDK v2 for S3.

This pr switches to using the CRT-based async S3 client. The put method still copies the bitstream to a temporary file and uploads, but the upload will occur in parallel chunks according to the configuration. (See the throughput and part size properties.) The get method no longer chunk the S3 objects into temporary files and instead the transfer occurs in parallel according to the configuration.

It turns out s3mock will not work with v2. See for example: https://github.com/findify/s3mock/issues/10. To solve the problem I switched to the adobe S3 mocking library.

Switching to AWS SDK v2 revealed an existing problem. The iiif-apis library loads the resource "mime.types" without a path. Resources of that name are provided by several libraries and it happens to load one it can't parse. This is a reported issue, see: https://github.com/dbmdz/iiif-apis/issues/270. I fixed it temporarily by changing the order of maven dependencies which also changes the classpath order and makes sure the "mime.types" from iiif-apis is found first.

The tests pass, but code coverage fails, probably because of auth issues when running in a fork. Fixed by updating the github workflow.


TODO:
  * What testing should be done on stage to give us confidence?
