### PR TITLE
Change S3 bitstore put method to avoid creating a temporary file

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -303,8 +303,8 @@ public class S3BitStoreService extends BaseBitStoreService {
     public void put(Bitstream bitstream, InputStream in) throws IOException {
         String key = getFullKey(bitstream.getInternalId());
 
-        try (DigestInputStream dis = new DigestInputStream(in, MessageDigest.getInstance(CSA))) {
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (DigestInputStream dis = new DigestInputStream(in, MessageDigest.getInstance(CSA));
+                ExecutorService executor = Executors.newSingleThreadExecutor()) {
             AsyncRequestBody body = AsyncRequestBody.fromInputStream(dis, null, executor);
 
             s3AsyncClient.putObject(b ->  b.bucket(bucketName).key(key).checksumAlgorithm(s3ChecksumAlgorithm),

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -302,9 +302,9 @@ public class S3BitStoreService extends BaseBitStoreService {
     @Override
     public void put(Bitstream bitstream, InputStream in) throws IOException {
         String key = getFullKey(bitstream.getInternalId());
+        ExecutorService executor = Executors.newSingleThreadExecutor();
 
-        try (DigestInputStream dis = new DigestInputStream(in, MessageDigest.getInstance(CSA));
-                ExecutorService executor = Executors.newSingleThreadExecutor()) {
+        try (DigestInputStream dis = new DigestInputStream(in, MessageDigest.getInstance(CSA))) {
             AsyncRequestBody body = AsyncRequestBody.fromInputStream(dis, null, executor);
 
             s3AsyncClient.putObject(b ->  b.bucket(bucketName).key(key).checksumAlgorithm(s3ChecksumAlgorithm),
@@ -327,6 +327,7 @@ public class S3BitStoreService extends BaseBitStoreService {
             // Should never happen
             log.warn("Caught NoSuchAlgorithmException", nsae);
         } finally {
+            executor.shutdown();
             in.close();
         }
     }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -9,8 +9,6 @@ package org.dspace.storage.bitstore;
 
 import static java.lang.String.valueOf;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestInputStream;
@@ -20,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import org.apache.commons.cli.CommandLine;
@@ -302,26 +302,21 @@ public class S3BitStoreService extends BaseBitStoreService {
     @Override
     public void put(Bitstream bitstream, InputStream in) throws IOException {
         String key = getFullKey(bitstream.getInternalId());
-        //Copy istream to temp file, and send the file, with some metadata
-        File scratchFile = File.createTempFile(bitstream.getInternalId(), "s3bs");
-        try (
-                FileOutputStream fos = new FileOutputStream(scratchFile);
-                // Read through a digest input stream that will work out the MD5
-                DigestInputStream dis = new DigestInputStream(in, MessageDigest.getInstance(CSA));
-        ) {
-            Utils.bufferedCopy(dis, fos);
-            in.close();
 
-            AsyncRequestBody body = AsyncRequestBody.fromFile(scratchFile);
+        try (DigestInputStream dis = new DigestInputStream(in, MessageDigest.getInstance(CSA))) {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            AsyncRequestBody body = AsyncRequestBody.fromInputStream(dis, null, executor);
+
             s3AsyncClient.putObject(b ->  b.bucket(bucketName).key(key).checksumAlgorithm(s3ChecksumAlgorithm),
                     body).join();
-            bitstream.setSizeBytes(scratchFile.length());
+
+            bitstream.setSizeBytes(s3AsyncClient.headObject(r -> r.bucket(bucketName).key(key))
+                    .join().contentLength());
 
             // we cannot use the S3 ETAG here as it could be not a MD5 in case of multipart upload (large files) or if
             // the bucket is encrypted
             bitstream.setChecksum(Utils.toHex(dis.getMessageDigest().digest()));
             bitstream.setChecksumAlgorithm(CSA);
-
         } catch (CompletionException e) {
             log.error("put(" + bitstream.getInternalId() + ", is)", e.getCause());
             throw new IOException(e.getCause());
@@ -332,9 +327,7 @@ public class S3BitStoreService extends BaseBitStoreService {
             // Should never happen
             log.warn("Caught NoSuchAlgorithmException", nsae);
         } finally {
-            if (!scratchFile.delete()) {
-                scratchFile.deleteOnExit();
-            }
+            in.close();
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -61,9 +60,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.Bucket;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ObjectAttributes;
 
 /**
  * @author Luca Giamminonni (luca.giamminonni at 4science.com)
@@ -158,13 +155,6 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
         InputStream inputStream = s3BitStoreService.get(bitstream);
         assertThat(IOUtils.toString(inputStream, UTF_8), is(content));
-
-        String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
-
-        GetObjectAttributesResponse response = s3AsyncClient.getObjectAttributes(r -> r.bucket(bucketName).key(key)
-                .objectAttributes(ObjectAttributes.CHECKSUM)).join();
-        expectedChecksum = Base64.getEncoder().encodeToString(generateChecksum("SHA-256", content));
-        assertThat(response.checksum().checksumSHA256(), is(expectedChecksum));
     }
 
     @Test
@@ -195,13 +185,6 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
         InputStream inputStream = s3BitStoreService.get(bitstream);
         assertThat(IOUtils.toString(inputStream, UTF_8), is(content));
-
-        String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
-        GetObjectAttributesResponse response = s3AsyncClient.getObjectAttributes(r ->
-            r.bucket(DEFAULT_BUCKET_NAME).key(key).objectAttributes(ObjectAttributes.CHECKSUM)).join();
-
-        expectedChecksum = Base64.getEncoder().encodeToString(generateChecksum("SHA-256", content));
-        assertThat(response.checksum().checksumSHA256(), is(expectedChecksum));
     }
 
     @Test


### PR DESCRIPTION
Note the checksum tests that were really just checking that s3 computed sha-256 correctly which doesn't seem meaningful. The test can no longer be done because the S3 checksum type is now composite when using the CRT client like this.