### PR TITLE
[cherry pick] solar-export-statistics last day option fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -556,7 +556,7 @@ public class SolrImportExport {
             YearMonth monthStartDate;
             String monthStart = monthFacet.getValue();
             try {
-                monthStartDate = YearMonth.parse(monthStart);
+                monthStartDate = YearMonth.parse(monthStart, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
             } catch (DateTimeParseException e) {
                 throw new SolrImportExportException("Could not read start of month batch as date: " + monthStart, e);
             }


### PR DESCRIPTION
This PR contains a cherry picked commit from the upstream commit https://github.com/DSpace/DSpace/commit/1b577937c69bb4ba164ddce94004d23a7139bcca

This will fix the date format exception in the SolarImportExport class when passing the `-l` last day option.