### PR TITLE
Ensure that bitstream downloads always have content-disposition set

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -221,6 +221,8 @@ public class BitstreamRestController {
             if ((dispositionThreshold >= 0 && filesize > dispositionThreshold)
                     || checkFormatForContentDisposition(format)) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
+            } else {
+                httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_INLINE);
             }
 
             // Send the data


### PR DESCRIPTION
If you look at items like https://dspace-stage.library.jhu.edu/items/2bd88d5b-99ae-4bc9-a42f-1684ea4fadd2/full and try to download bitstreams you will have some filename problems. Sometimes bitstreams downloads do not have the original filename set by default and seem to oddly switch between attachment and inline content dispositions.

This is because the BitstreamRestController does not always set the content disposition header. It allows the logic to slip through to `HttpHeadersInitializer` which conditionally sets the header. (The logic is also quite confusing. I don't understand the special case for non-images.) Reading through the controller, it seems like it should make the decision itself.

The simplest way to test will be to deploy the branch. You can also test locally by building the image in the DSpace repo with `docker build -t ghcr.io/jhu-sheridan-libraries/jhu-dspace:foo .` and then editing the local-test environment to use that image.


