### PR TITLE
Update to the lastest S3 client

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -734,7 +734,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.32.31</version>
+            <version>2.41.10</version>
             <exclusions>
               <exclusion>
                 <groupId>software.amazon.awssdk</groupId>
@@ -750,7 +750,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.38.12</version>
+            <version>0.42.2</version>
         </dependency>
 
         <!-- TODO: This may need to be replaced with the "orcid-model" artifact once this ticket is resolved:
@@ -866,7 +866,7 @@
         <dependency>
           <groupId>com.adobe.testing</groupId>
           <artifactId>s3mock-testcontainers</artifactId>
-          <version>4.8.0</version>
+          <version>4.11.0</version>
           <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This updates to the latest crt s3 client which has read back pressure support automatically enabled as well as some memory leak fixes.

The CurationScriptIT script is failing due to a known issue which has been fixed in 9.2. See https://github.com/DSpace/DSpace/pull/11647.