### PR TITLE
Add OrderedAccessStatusHelper implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
     # Must run after 'tests' job above
     needs: tests
     runs-on: ubuntu-latest
+    # Do not run on forks since it will fail without the token
+    if: github.repository == 'dspace/dspace'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/dspace-api/src/main/java/org/dspace/access/status/OrderedAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/OrderedAccessStatusHelper.java
@@ -1,0 +1,83 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.access.status;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+import org.dspace.content.AccessStatus;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+/**
+ * Implementation of the access status helper that uses an ordered list of access statuses to enforce an order
+ * of precedence when there are multiple bitstreams in the original bundle that have difference policies.
+ */
+public class OrderedAccessStatusHelper extends DefaultAccessStatusHelper {
+
+    private static final List<String> ORDERED_BITSTREAM_STATUSES = List.of(EMBARGO, RESTRICTED, UNKNOWN, OPEN_ACCESS);
+
+    /**
+     * Iterate over all the bitstreams in the item's original bundle, calculate the access status for each bitstream,
+     * and select the access status with the most precedence based on the ORDERED_BITSTREAM_STATUSES list. The access
+     * status with the highest precedence is at index 0 in the list.
+     * <p>
+     * If the item Original bundle is empty, "metadata.only" is returned.
+     * <p>
+     * If the item is null, simply returns the "unknown" value.
+     *
+     * @param context     the DSpace context
+     * @param item        the item to check for embargoes
+     * @param threshold   the embargo threshold date
+     * @param type        the type of calculation
+     * @return the access status
+     */
+    @Override
+    public AccessStatus getAccessStatusFromItem(Context context, Item item, LocalDate threshold, String type) {
+        if (item == null) {
+            return new AccessStatus(UNKNOWN, null);
+        }
+
+        final List<Bundle> bundles = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
+
+        boolean noBitstreamsInBundles = bundles.stream()
+            .allMatch(bundle -> bundle.getBitstreams().isEmpty());
+
+        if (noBitstreamsInBundles) {
+            return new AccessStatus(METADATA_ONLY, null);
+        }
+
+        return getAccessStatusForItemBitstreams(context, bundles, threshold, type);
+    }
+
+    private AccessStatus getAccessStatusForItemBitstreams(Context context, List<Bundle> bundles, LocalDate threshold,
+                                                          String type) {
+        return bundles.stream()
+            .map(Bundle::getBitstreams)
+            .flatMap(List::stream)
+            .map(bitstream -> getAccessStatusForBitstreamSafe(context, bitstream, threshold, type))
+            .min(Comparator.comparingInt(
+                accessStatus -> ORDERED_BITSTREAM_STATUSES.indexOf(accessStatus.getStatus())
+            ))
+            .orElseGet(() -> new AccessStatus(UNKNOWN, null));
+    }
+
+    private AccessStatus getAccessStatusForBitstreamSafe(Context context, Bitstream bitstream, LocalDate threshold,
+                                                         String type) {
+        try {
+            return getAccessStatusFromBitstream(context, bitstream, threshold, type);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/access/status/OrderedAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/OrderedAccessStatusHelper.java
@@ -67,7 +67,14 @@ public class OrderedAccessStatusHelper extends DefaultAccessStatusHelper {
             .flatMap(List::stream)
             .map(bitstream -> getAccessStatusForBitstreamSafe(context, bitstream, threshold, type))
             .min(Comparator.comparingInt(
-                accessStatus -> ORDERED_BITSTREAM_STATUSES.indexOf(accessStatus.getStatus())
+                accessStatus -> {
+                    int index = ORDERED_BITSTREAM_STATUSES.indexOf(accessStatus.getStatus());
+                    if (index == -1) {
+                        throw new RuntimeException("Access status " + accessStatus.getStatus() +
+                            " not found in ordered list");
+                    }
+                    return index;
+                }
             ))
             .orElseGet(() -> new AccessStatus(UNKNOWN, null));
     }

--- a/dspace-api/src/test/java/org/dspace/access/status/AbstractAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AbstractAccessStatusHelperTest.java
@@ -1,0 +1,593 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.access.status;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.AccessStatus;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.BundleService;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.InstallItemService;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractAccessStatusHelperTest extends AbstractUnitTest {
+
+    private static final Logger log = LogManager.getLogger(AbstractAccessStatusHelperTest.class);
+
+    protected Collection collection;
+    protected Community owningCommunity;
+    protected Item itemWithoutBundle;
+    protected Item itemWithoutBitstream;
+    protected Item itemWithBitstream;
+    protected Item itemWithEmbargo;
+    protected Item itemWithDateRestriction;
+    protected Item itemWithGroupRestriction;
+    protected Item itemWithoutPolicy;
+    protected Item itemWithoutPrimaryBitstream;
+    protected Item itemWithPrimaryAndMultipleBitstreams;
+    protected Item itemWithoutPrimaryAndMultipleBitstreams;
+    protected AccessStatusHelper helper;
+    protected LocalDate threshold;
+
+    protected CommunityService communityService =
+            ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService =
+            ContentServiceFactory.getInstance().getCollectionService();
+    protected ItemService itemService =
+            ContentServiceFactory.getInstance().getItemService();
+    protected WorkspaceItemService workspaceItemService =
+            ContentServiceFactory.getInstance().getWorkspaceItemService();
+    protected InstallItemService installItemService =
+            ContentServiceFactory.getInstance().getInstallItemService();
+    protected BundleService bundleService =
+            ContentServiceFactory.getInstance().getBundleService();
+    protected BitstreamService bitstreamService =
+            ContentServiceFactory.getInstance().getBitstreamService();
+    protected ResourcePolicyService resourcePolicyService =
+            AuthorizeServiceFactory.getInstance().getResourcePolicyService();
+    protected GroupService groupService =
+            EPersonServiceFactory.getInstance().getGroupService();
+    protected EPersonService ePersonService =
+            EPersonServiceFactory.getInstance().getEPersonService();
+
+    /**
+     * This method will be run before every test as per @Before. It will
+     * initialize resources required for the tests.
+     *
+     * Other methods can be annotated with @Before here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @Before
+    @Override
+    public void init() {
+        super.init();
+        try {
+            context.turnOffAuthorisationSystem();
+            owningCommunity = communityService.create(null, context);
+            collection = collectionService.create(context, owningCommunity);
+            itemWithoutBundle = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutBitstream = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithBitstream = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithEmbargo = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithDateRestriction = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithGroupRestriction = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutPolicy = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutPrimaryBitstream = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithPrimaryAndMultipleBitstreams = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutPrimaryAndMultipleBitstreams = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            context.restoreAuthSystemState();
+        } catch (AuthorizeException ex) {
+            log.error("Authorization Error in init", ex);
+            fail("Authorization Error in init: " + ex.getMessage());
+        } catch (SQLException ex) {
+            log.error("SQL Error in init", ex);
+            fail("SQL Error in init: " + ex.getMessage());
+        }
+        threshold = LocalDate.of(10000, 1, 1);
+    }
+
+    /**
+     * This method will be run after every test as per @After. It will
+     * clean resources initialized by the @Before methods.
+     *
+     * Other methods can be annotated with @After here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @After
+    @Override
+    public void destroy() {
+        context.turnOffAuthorisationSystem();
+        try {
+            itemService.delete(context, itemWithoutBundle);
+            itemService.delete(context, itemWithoutBitstream);
+            itemService.delete(context, itemWithBitstream);
+            itemService.delete(context, itemWithEmbargo);
+            itemService.delete(context, itemWithDateRestriction);
+            itemService.delete(context, itemWithGroupRestriction);
+            itemService.delete(context, itemWithoutPolicy);
+            itemService.delete(context, itemWithoutPrimaryBitstream);
+            itemService.delete(context, itemWithPrimaryAndMultipleBitstreams);
+            itemService.delete(context, itemWithoutPrimaryAndMultipleBitstreams);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            collectionService.delete(context, collection);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            communityService.delete(context, owningCommunity);
+        } catch (Exception e) {
+            // ignore
+        }
+        context.restoreAuthSystemState();
+        itemWithoutBundle = null;
+        itemWithoutBitstream = null;
+        itemWithBitstream = null;
+        itemWithEmbargo = null;
+        itemWithDateRestriction = null;
+        itemWithGroupRestriction = null;
+        itemWithoutPolicy = null;
+        itemWithoutPrimaryBitstream = null;
+        itemWithPrimaryAndMultipleBitstreams = null;
+        itemWithoutPrimaryAndMultipleBitstreams = null;
+        collection = null;
+        owningCommunity = null;
+        helper = null;
+        threshold = null;
+        communityService = null;
+        collectionService = null;
+        itemService = null;
+        workspaceItemService = null;
+        installItemService = null;
+        bundleService = null;
+        bitstreamService = null;
+        resourcePolicyService = null;
+        groupService = null;
+        try {
+            super.destroy();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    /**
+     * Test for a null item
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithNullItem() throws Exception {
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithNullItem 1", availabilityDate);
+    }
+
+    /**
+     * Test for an item with no bundle
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutBundle() throws Exception {
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutBundle, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithoutBundle 1", availabilityDate);
+    }
+
+    /**
+     * Test for an item with no bitstream
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        bundleService.create(context, itemWithoutBitstream, Constants.CONTENT_BUNDLE_NAME);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithoutBitstream 1", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithoutBitstream 4", bitstreamAvailabilityDate);
+    }
+
+    /**
+     * Test for an item with a basic bitstream (open access)
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithBitstream, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithBitstream 1", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithBitstream 4", bitstreamAvailabilityDate);
+    }
+
+    /**
+     * Test for an item with an embargo
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargo() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargo 1", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargo 4", bitstreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with an anonymous date restriction
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithDateRestriction() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithDateRestriction, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Restriction");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(10000, 1, 1);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithDateRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithDateRestriction 1", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithDateRestriction 4", bistreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with a group restriction
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithGroupRestriction() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithGroupRestriction, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Restriction");
+        policy.setAction(Constants.READ);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithGroupRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithGroupRestriction 1", availabilityDate, equalTo(threshold));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithGroupRestriction 4", bitstreamAvailabilityDate, equalTo(threshold));
+    }
+
+    /**
+     * Test for an item with no policy
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutPolicy() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithoutPolicy, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        authorizeService.removeAllPolicies(context, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutPolicy, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithoutPolicy 1", availabilityDate, equalTo(threshold));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithoutPolicy 4", bitstreamAvailabilityDate, equalTo(threshold));
+    }
+
+    /**
+     * Test for an item with no primary bitstream
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutPrimaryBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithoutPrimaryBitstream, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "first");
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutPrimaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithoutPrimaryBitstream 1", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithoutPrimaryBitstream 4", bitstreamAvailabilityDate);
+    }
+
+    /**
+     * Test for an item with an embargo for both configurations (current, anonymous) and as a guest
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargoForCurrentOrAnonymousAsGuest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        EPerson admin = ePersonService.create(context);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy adminPolicy = resourcePolicyService.create(context, admin, adminGroup);
+        adminPolicy.setRpName("Open Access For Admin");
+        adminPolicy.setAction(Constants.READ);
+        policies.add(adminPolicy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // Configuration: current
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 1", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 2", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 3", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 4", bistreamAvailabilityDate, equalTo(startDate));
+        // Configuration: anonymous
+        // getAccessStatusFromItem
+        accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 5", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 6", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 7", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 8", bistreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with an embargo for both configurations (current, anonymous) and as an admin
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargoForCurrentOrAnonymousAsAdmin() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        EPerson admin = ePersonService.create(context);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy adminPolicy = resourcePolicyService.create(context, admin, adminGroup);
+        adminPolicy.setRpName("Open Access For Admin");
+        adminPolicy.setAction(Constants.READ);
+        policies.add(adminPolicy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        EPerson currentUser = context.getCurrentUser();
+        context.setCurrentUser(admin);
+        // Configuration: current
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 1", status,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 2", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 3", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 4", bitstreamAvailabilityDate);
+        // Configuration: anonymous
+        accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 5", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 6", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 7", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 8", bitstreamAvailabilityDate, equalTo(startDate));
+        context.setCurrentUser(currentUser);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/access/status/OrderedAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/OrderedAccessStatusHelperTest.java
@@ -30,7 +30,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DefaultAccessStatusHelperTest extends AbstractAccessStatusHelperTest {
+public class OrderedAccessStatusHelperTest extends AbstractAccessStatusHelperTest {
 
     @Before
     @Override
@@ -40,7 +40,7 @@ public class DefaultAccessStatusHelperTest extends AbstractAccessStatusHelperTes
         PluginService pluginService = CoreServiceFactory.getInstance().getPluginService();
         configurationService.setProperty(
             "plugin.single.org.dspace.access.status.AccessStatusHelper",
-            "org.dspace.access.status.DefaultAccessStatusHelper"
+            "org.dspace.access.status.OrderedAccessStatusHelper"
         );
         helper = (AccessStatusHelper) pluginService.getSinglePlugin(AccessStatusHelper.class);
     }
@@ -125,10 +125,10 @@ public class DefaultAccessStatusHelperTest extends AbstractAccessStatusHelperTes
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status,
-            equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 1", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
-        assertNull("testWithNoPrimaryAndMultipleBitstreams 1", availabilityDate);
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 2", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream -> first
         AccessStatus accessStatusFirstBitstream = helper.getAccessStatusFromBitstream(context,
                 firstBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);

--- a/dspace-api/src/test/resources/docker-java.properties
+++ b/dspace-api/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemDefaultAccessStatusRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemDefaultAccessStatusRestRepositoryIT.java
@@ -1,0 +1,129 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.time.Period;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.junit.Test;
+
+public class ItemDefaultAccessStatusRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void findAccessStatusForItemBadRequestTest() throws Exception {
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", "1"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findAccessStatusForItemNotFoundTest() throws Exception {
+        UUID fakeUUID = UUID.randomUUID();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", fakeUUID))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findAccessStatusForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", notNullValue()))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoDateForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+            .withName("test.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", notNullValue()))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        InputStream is2 = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-embargo.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("open.access")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
@@ -1,0 +1,293 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.time.Period;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.access.status.AccessStatusServiceImpl;
+import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ItemOrderedAccessStatusRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AccessStatusService accessStatusService;
+
+    @Before
+    public void setup() throws Exception {
+        configurationService.setProperty(
+            "plugin.single.org.dspace.access.status.AccessStatusHelper",
+            "org.dspace.access.status.OrderedAccessStatusHelper"
+        );
+        // This is needed because the AccessStatusHelper is a plugin that is created and set in the
+        // AccessStatusServiceImpl.init method. AccessStatusService is a spring managed bean, and the context has
+        // already been created by the time the test method runs.
+        ReflectionTestUtils.setField(accessStatusService, "helper", null);
+        ((AccessStatusServiceImpl) accessStatusService).init();
+
+    }
+
+    @Test
+    public void findAccessStatusForItemBadRequestTest() throws Exception {
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", "1"))
+                   .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findAccessStatusForItemNotFoundTest() throws Exception {
+        UUID fakeUUID = UUID.randomUUID();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", fakeUUID))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findAccessStatusWithMetatdataOnlyForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Owning Collection")
+                                                       .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+                               .withTitle("Test item")
+                               .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.status", is("metadata.only")))
+                   .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+            .withName("test.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("open.access")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Owning Collection")
+                                                       .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+                               .withTitle("Test item")
+                               .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        InputStream is = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                              .withName("test.pdf")
+                                              .withMimeType("application/pdf")
+                                              .withEmbargoPeriod(Period.ofMonths(6))
+                                              .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.status", is("embargo")))
+                   .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithRestrictedForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        GroupBuilder internalGroupBuilder = GroupBuilder.createGroup(context)
+            .withName("Internal Group");
+        Group internalGroup = internalGroupBuilder.build();
+        InputStream is2 = IOUtils.toInputStream("restrictedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-restricted.pdf")
+            .withMimeType("application/pdf")
+            .withReaderGroup(internalGroup)
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("restricted")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        InputStream is2 = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-embargo.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("embargo")))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithRestrictedAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        GroupBuilder internalGroupBuilder = GroupBuilder.createGroup(context)
+            .withName("Internal Group");
+        Group internalGroup = internalGroupBuilder.build();
+        InputStream is2 = IOUtils.toInputStream("restrictedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-restricted.pdf")
+            .withMimeType("application/pdf")
+            .withReaderGroup(internalGroup)
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("restricted")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoAndRestrictedAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        GroupBuilder internalGroupBuilder = GroupBuilder.createGroup(context)
+            .withName("Internal Group");
+        Group internalGroup = internalGroupBuilder.build();
+        InputStream is2 = IOUtils.toInputStream("restrictedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-restricted.pdf")
+            .withMimeType("application/pdf")
+            .withReaderGroup(internalGroup)
+            .build();
+        InputStream is3 = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is3)
+            .withName("test-embargo.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("embargo")))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
@@ -34,6 +34,7 @@ import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +59,19 @@ public class ItemOrderedAccessStatusRestRepositoryIT extends AbstractControllerI
         // already been created by the time the test method runs.
         ReflectionTestUtils.setField(accessStatusService, "helper", null);
         ((AccessStatusServiceImpl) accessStatusService).init();
+    }
 
+    @After
+    public void reset() throws Exception {
+        configurationService.setProperty(
+            "plugin.single.org.dspace.access.status.AccessStatusHelper",
+            "org.dspace.access.status.DefaultAccessStatusHelper"
+        );
+        // This is needed because the AccessStatusHelper is a plugin that is created and set in the
+        // AccessStatusServiceImpl.init method. AccessStatusService is a spring managed bean, and the context has
+        // already been created by the time the test method runs.
+        ReflectionTestUtils.setField(accessStatusService, "helper", null);
+        ((AccessStatusServiceImpl) accessStatusService).init();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.app.rest;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -4723,66 +4723,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
-    public void findAccessStatusForItemBadRequestTest() throws Exception {
-        getClient().perform(get("/api/core/items/{uuid}/accessStatus", "1"))
-                   .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    public void findAccessStatusForItemNotFoundTest() throws Exception {
-        UUID fakeUUID = UUID.randomUUID();
-        getClient().perform(get("/api/core/items/{uuid}/accessStatus", fakeUUID))
-                   .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void findAccessStatusForItemTest() throws Exception {
-        context.turnOffAuthorisationSystem();
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
-                                                       .withName("Owning Collection")
-                                                       .build();
-        Item item = ItemBuilder.createItem(context, owningCollection)
-                               .withTitle("Test item")
-                               .build();
-        context.restoreAuthSystemState();
-        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.status", notNullValue()))
-                   .andExpect(jsonPath("$.embargoDate", nullValue()));
-    }
-
-    @Test
-    public void findAccessStatusWithEmbargoDateForItemTest() throws Exception {
-        context.turnOffAuthorisationSystem();
-        parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
-        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
-                                                       .withName("Owning Collection")
-                                                       .build();
-        Item item = ItemBuilder.createItem(context, owningCollection)
-                               .withTitle("Test item")
-                               .build();
-        Bundle originalBundle = BundleBuilder.createBundle(context, item)
-                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
-                                             .build();
-        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
-        Bitstream bitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
-                                              .withName("test.pdf")
-                                              .withMimeType("application/pdf")
-                                              .withEmbargoPeriod(Period.ofMonths(6))
-                                              .build();
-        context.restoreAuthSystemState();
-        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.status", notNullValue()))
-                   .andExpect(jsonPath("$.embargoDate", notNullValue()));
-    }
-
-    @Test
     public void findSubmitterByAdminTest() throws Exception {
         context.turnOffAuthorisationSystem();
 


### PR DESCRIPTION
In order to better support multiple bitstreams in the original bundle with different access policies, a new AccessStatusHelper implementation has been added named `OrderedAccessStatusHelper`.

`OrderedAccessStatusHelper` extends `DefaultAccessStatusHelper` and overrides the logic for computing the AccessStatus object for an Item. The logic is to iterate over all the bitstreams in the Orginal bundle, create AccessStatus objects for each, then return the AccessStatus with the highest precedence as determine by the matching value in `ORDERED_BITSTREAM_STATUSES` list.

The unit and integration tests for `DefaultAccessStatusHelper` were refactored so that tests could be run for both `DefaultAccessStatusHelper` and `OrderedAccessStatusHelper` where appropriate, along with some new tests for `OrderedAccessStatusHelper`.

To test locally, you can build the docker image for this repo on this branch. Ensure you have `plugin.single.org.dspace.access.status.AccessStatusHelper = org.dspace.access.status.OrderedAccessStatusHelper` in the local.cfg when you start the container in local-test.
