### PR TITLE
Interim fix for SWORD/TEXT bundle admin-only policies

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -405,6 +405,12 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             //Set permissions on the derivative bitstream
             updatePoliciesOfDerivativeBitstream(context, b, formatFilter, source);
 
+            //TEXT bundles and bitstreams are admin-only
+            //TODO Interim fix for https://github.com/DSpace/dspace/issues/11871
+            if ("TEXT".equals(targetBundle.getName())) {
+                authorizeService.replaceBundlePoliciesWithAdminOnly(context, targetBundle);
+            }
+
             //do post-processing of the generated bitstream
             formatFilter.postProcessBitstream(context, item, b);
 

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -1001,6 +1001,26 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         }
     }
 
+    @Override
+    public void replaceBundlePoliciesWithAdminOnly(Context context, Bundle bundle)
+        throws SQLException, AuthorizeException {
+        replaceAllDsoPoliciesWithAdminOnly(context, bundle);
+        bundle.getBitstreams().forEach(bitstream -> {
+            try {
+                replaceAllDsoPoliciesWithAdminOnly(context, bitstream);
+            } catch (SQLException | AuthorizeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void replaceAllDsoPoliciesWithAdminOnly(Context context, DSpaceObject dso)
+        throws SQLException, AuthorizeException {
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        removeAllPolicies(context, dso);
+        addPolicy(context, dso, Constants.READ, adminGroup, ResourcePolicy.TYPE_CUSTOM);
+    }
+
     /**
      * Check whether or not there is already an RP on the given dso, which has actionId={@link Constants.READ} and
      * resourceTypeId={@link ResourcePolicy.TYPE_CUSTOM}

--- a/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
@@ -623,5 +624,17 @@ public interface AuthorizeService {
 
     public void addCustomPoliciesNotInPlace(Context context, DSpaceObject dso,
             List<ResourcePolicy> defaultCollectionPolicies) throws SQLException, AuthorizeException;
+
+    /**
+     * Replace all the policies for the bundle with admin-only policies. The policies of the bitstreams in the bundle
+     * will also be replaced with admin-only policies.
+     *
+     * @param context DSpace Context
+     * @param bundle  bundle to update policies to admin-only
+     * @throws SQLException       if there's a database problem
+     * @throws AuthorizeException if the current user is not authorized to replace these policies
+     */
+    void replaceBundlePoliciesWithAdminOnly(Context context, Bundle bundle)
+        throws SQLException, AuthorizeException;
 
 }

--- a/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.mediafilter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -19,6 +21,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -32,6 +37,7 @@ import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +50,7 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
 
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    private AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     protected Community topComm1;
     protected Community topComm2;
     protected Community childComm1_1;
@@ -191,7 +198,7 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
         assertTrue("The item " + item.getName() + " should NOT have the TEXT bundle", textBundles.size() == 0);
     }
 
-    private void checkItemHasBeenProcessed(Item item) throws IOException, SQLException, AuthorizeException {
+    private void checkItemHasBeenProcessed(Item item) throws Exception {
         String expectedFileName = StringUtils.endsWith(item.getName(), "_a") ? "test.csv.txt" : "test.txt.txt";
         String expectedContent = StringUtils.endsWith(item.getName(), "_a") ? "data3,3" : "quick brown fox";
         List<Bundle> textBundles = item.getBundles("TEXT");
@@ -203,11 +210,35 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
                 StringUtils.equals(bitstreams.get(0).getName(), expectedFileName));
         assertTrue("The text bitstream in the " + item.getName() + " doesn't contain the proper content ["
                 + expectedContent + "]", StringUtils.contains(getContent(bitstreams.get(0)), expectedContent));
+
+        // Verify the TEXT bundle and bitstream have only admin-only resource policies.
+        assertEquals(1, textBundles.size());
+        Bundle textBundle = textBundles.get(0);
+
+        List<ResourcePolicy> bundlePolicies = authorizeService.getPolicies(context, textBundle);
+        verifyAdminOnlyPolicies(bundlePolicies);
+
+        assertEquals(1, textBundle.getBitstreams().size());
+        Bitstream bitstream = textBundle.getBitstreams().get(0);
+        List<ResourcePolicy> bitstreamPolicies = authorizeService.getPolicies(context, bitstream);
+        verifyAdminOnlyPolicies(bitstreamPolicies);
+    }
+
+    private void verifyAdminOnlyPolicies(List<ResourcePolicy> resourcePolicies) throws Exception {
+        assertEquals(1, resourcePolicies.size());
+        ResourcePolicy resourcePolicy = resourcePolicies.get(0);
+        assertEquals(context.getAdminGroup(), resourcePolicy.getGroup());
+        assertEquals(Constants.READ, resourcePolicy.getAction());
+        assertEquals(ResourcePolicy.TYPE_CUSTOM, resourcePolicy.getRpType());
+        assertNull(resourcePolicy.getEPerson());
     }
 
     private CharSequence getContent(Bitstream bitstream) throws IOException, SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
         try (InputStream input = bitstreamService.retrieve(context, bitstream)) {
             return IOUtils.toString(input, "UTF-8");
+        } finally {
+            context.restoreAuthSystemState();
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/sword/Swordv1IT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/sword/Swordv1IT.java
@@ -12,15 +12,25 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.lang3.stream.Streams;
 import org.dspace.app.rest.test.AbstractWebClientIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assume;
@@ -53,6 +63,12 @@ public class Swordv1IT extends AbstractWebClientIntegrationTest {
 
     @Autowired
     private ConfigurationService configurationService;
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
 
     // All SWORD paths that we test against
     private final String SERVICE_DOC_PATH = "/sword/servicedocument";
@@ -180,6 +196,27 @@ public class Swordv1IT extends AbstractWebClientIntegrationTest {
         // Body should include a link to the zip bitstream in the newly created Item
         // This just verifies "example.zip" exists in the body.
         MatcherAssert.assertThat(response.getBody(), containsString("example.zip"));
+
+        // Verify the sword bundle and bitstream have only admin-only resource policies.
+        Iterator<Item> itemsIterator = itemService.findByCollection(context, collection);
+
+        Item foundItem = Streams.of(itemsIterator)
+            .filter(item -> item.getName().contains("Attempts to detect retrotransposition"))
+            .findFirst()
+            .get();
+        List<Bundle> swordBundles = foundItem.getBundles().stream()
+            .filter(bundle -> bundle.getName().equals("SWORD"))
+            .toList();
+        assertEquals(1, swordBundles.size());
+        Bundle swordBundle = swordBundles.get(0);
+
+        List<ResourcePolicy> bundlePolicies = authorizeService.getPolicies(context, swordBundle);
+        verifyAdminOnlyPolicies(bundlePolicies);
+
+        assertEquals(1, swordBundle.getBitstreams().size());
+        Bitstream bitstream = swordBundle.getBitstreams().get(0);
+        List<ResourcePolicy> bitstreamPolicies = authorizeService.getPolicies(context, bitstream);
+        verifyAdminOnlyPolicies(bitstreamPolicies);
     }
 
     @Test
@@ -190,6 +227,15 @@ public class Swordv1IT extends AbstractWebClientIntegrationTest {
         assertThat(response.getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
 
         //NOTE: An authorized /media-link test is performed in depositTest() above.
+    }
+
+    private void verifyAdminOnlyPolicies(List<ResourcePolicy> resourcePolicies) throws Exception {
+        assertEquals(1, resourcePolicies.size());
+        ResourcePolicy resourcePolicy = resourcePolicies.get(0);
+        assertEquals(context.getAdminGroup(), resourcePolicy.getGroup());
+        assertEquals(Constants.READ, resourcePolicy.getAction());
+        assertEquals(ResourcePolicy.TYPE_CUSTOM, resourcePolicy.getRpType());
+        assertNull(resourcePolicy.getEPerson());
     }
 }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/sword2/Swordv2IT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/sword2/Swordv2IT.java
@@ -12,19 +12,28 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.lang3.stream.Streams;
 import org.dspace.app.rest.test.AbstractWebClientIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.WorkflowItemBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.services.ConfigurationService;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.junit.Assume;
@@ -60,6 +69,12 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
 
     @Autowired
     private ConfigurationService configurationService;
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
 
     // All SWORD v2 paths that we test against
     private final String SWORD_PATH = "/swordv2";
@@ -243,6 +258,8 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
         // Body should include that link as the rel="edit" URL
         assertThat(response.getBody(), containsString("<link href=\"" + editLink + "\" rel=\"edit\""));
 
+        verifyBundleAndBitstreamAdminOnly(collection);
+
         //----
         // STEP 2: Verify uploaded content can be read via SWORDv2
         //----
@@ -264,6 +281,8 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
         // Verify Item title also is returned in the body
         assertThat(response.getBody(), containsString("Attempts to detect retrotransposition"));
 
+        verifyBundleAndBitstreamAdminOnly(collection);
+
         //----
         // STEP 3: Verify uploaded content can be UPDATED via SWORDv2 (by an Admin ONLY)
         //----
@@ -283,6 +302,8 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
         // Expect a 200 OK response
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
+        verifyBundleAndBitstreamAdminOnly(collection);
+
         //----
         // STEP 4: Verify content was successfully updated by reading content again
         //----
@@ -297,6 +318,8 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         // Verify the new Item title is now included in the response body
         assertThat(response.getBody(), containsString(newTitle));
+
+        verifyBundleAndBitstreamAdminOnly(collection);
 
         //----
         // STEP 5: Verify archived Item can be DELETED via SWORDv2 (by an Admin ONLY)
@@ -526,6 +549,38 @@ public class Swordv2IT extends AbstractWebClientIntegrationTest {
         // Also verify Item is in "archived" state
         assertThat(response.getBody(),
                    containsString("<category term=\"http://dspace.org/state/archived\""));
+    }
+
+    private void verifyBundleAndBitstreamAdminOnly(Collection collection) throws Exception {
+        // Verify the sword bundle and bitstream have only admin-only resource policies.
+        Iterator<Item> itemsIterator = itemService.findByCollection(context, collection);
+
+        Item foundItem = Streams.of(itemsIterator)
+            .filter(item -> item.getName().contains("Attempts to detect retrotransposition"))
+            .findFirst()
+            .get();
+        List<Bundle> swordBundles = foundItem.getBundles().stream()
+            .filter(bundle -> bundle.getName().equals("SWORD"))
+            .toList();
+        assertEquals(1, swordBundles.size());
+        Bundle swordBundle = swordBundles.get(0);
+
+        List<ResourcePolicy> bundlePolicies = authorizeService.getPolicies(context, swordBundle);
+        verifyAdminOnlyPolicies(bundlePolicies);
+
+        assertEquals(1, swordBundle.getBitstreams().size());
+        Bitstream bitstream = swordBundle.getBitstreams().get(0);
+        List<ResourcePolicy> bitstreamPolicies = authorizeService.getPolicies(context, bitstream);
+        verifyAdminOnlyPolicies(bitstreamPolicies);
+    }
+
+    private void verifyAdminOnlyPolicies(List<ResourcePolicy> resourcePolicies) throws Exception {
+        assertEquals(1, resourcePolicies.size());
+        ResourcePolicy resourcePolicy = resourcePolicies.get(0);
+        assertEquals(context.getAdminGroup(), resourcePolicy.getGroup());
+        assertEquals(Constants.READ, resourcePolicy.getAction());
+        assertEquals(ResourcePolicy.TYPE_CUSTOM, resourcePolicy.getRpType());
+        assertNull(resourcePolicy.getEPerson());
     }
 }
 

--- a/dspace-sword/src/main/java/org/dspace/sword/CollectionDepositor.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/CollectionDepositor.java
@@ -15,6 +15,8 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
@@ -58,6 +60,10 @@ public class CollectionDepositor extends Depositor {
 
     private final ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private final AuthorizeService authorizeService =
+        AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
     /**
      * The DSpace Collection we are depositing into
      */
@@ -188,6 +194,9 @@ public class CollectionDepositor extends Depositor {
                 if (bf != null) {
                     bitstreamService.setFormat(context, bitstream, bf);
                 }
+
+                //TODO Interim fix for https://github.com/DSpace/dspace/issues/11871
+                authorizeService.replaceBundlePoliciesWithAdminOnly(context, swordBundle);
 
                 bitstreamService.update(context, bitstream);
                 bundleService.update(context, swordBundle);

--- a/dspace-sword/src/main/java/org/dspace/sword/ItemDepositor.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/ItemDepositor.java
@@ -15,6 +15,8 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
@@ -47,6 +49,9 @@ public class ItemDepositor extends Depositor {
 
     private final ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private final AuthorizeService authorizeService =
+        AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
     private Item item;
 
@@ -155,6 +160,9 @@ public class ItemDepositor extends Depositor {
                 if (bf != null) {
                     bitstreamService.setFormat(context, bitstream, bf);
                 }
+
+                //TODO Interim fix for https://github.com/DSpace/dspace/issues/11871
+                authorizeService.replaceBundlePoliciesWithAdminOnly(context, swordBundle);
 
                 bitstreamService.update(context, bitstream);
                 bundleService.update(context, swordBundle);

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
@@ -31,6 +31,8 @@ import java.util.TreeMap;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
@@ -71,6 +73,9 @@ public class DSpaceSwordAPI {
 
     protected ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private final AuthorizeService authorizeService =
+        AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
     public SwordContext noAuthContext()
         throws DSpaceSwordException {
@@ -343,6 +348,9 @@ public class DSpaceSwordAPI {
                         "Original deposit stored as " + fn +
                             ", in item bundle " + swordBundle);
                 }
+
+                //TODO Interim fix for https://github.com/DSpace/dspace/issues/11871
+                authorizeService.replaceBundlePoliciesWithAdminOnly(context, swordBundle);
 
                 bundleService.update(context, swordBundle);
                 itemService.update(context, item);


### PR DESCRIPTION
This PR is an interim fix for the SWORD and TEXT bundle/bitstream resource policy issue. The code change is a more surgical code change making specific calls to update resource policies of bundles and bitstreams at the point of creation in the code making the create calls. For example, when a SWORD bundle/bitstream is created in the sword code, it makes an additional call to the AuthorizeService to update all policies to admin-only.

The longer term fix will be similar, but will most likely be fully encapsulated within AuthorizeService and BundleService, a more cross-cutting change that will come later.

To test locally, compile and build a local docker image on this branch. We should test media-filter and sword deposits specifically.